### PR TITLE
Refine calculator layout cards

### DIFF
--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -145,12 +145,15 @@ table {
         display: flex;
         flex-direction: column;
         height: 100%;
+        align-items: center;
     }
     #leftright {
         display: flex;
         flex-direction: row;
         overflow-x: hidden;
         flex: 1;
+        padding: 40px 32px;
+        gap: 32px;
     }
     #footer {
         flex: 0;
@@ -193,6 +196,8 @@ table {
     #leftright {
         display: flex;
         flex-direction: column-reverse;
+        padding: 16px;
+        gap: 16px;
     }
     #left, #right {
         display: flex;
@@ -206,10 +211,17 @@ table {
 body {
     margin: 0;
     padding: 0;
+    background-color: #f5f5f5;
 }
 
 #leftright {
     @extend %white;
+    background-color: transparent;
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 24px;
+    gap: 24px;
 }
 
 #footer {
@@ -219,8 +231,16 @@ body {
 }
 
 #left, #right {
-    .header { 
+    background-color: $white;
+    border-radius: 12px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+    padding: 16px;
+    overflow: hidden;
+
+    .header {
         @extend %primary;
+        margin: -16px -16px 16px;
+        border-radius: 12px 12px 0 0;
 
         h3 {
             text-align: center;


### PR DESCRIPTION
## Summary
- introduce a soft neutral background and center the main layout container with responsive padding
- convert the left/right panels into card-like surfaces with rounded corners, padding, and header adjustments
- add responsive gaps between panels so the layout breathes on large screens while stacking cleanly on small devices

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68d149eca0288328af01e9189e98f5b9