### PR TITLE
Improve responsive layout spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <head>
 <title>World Rugby Rankings calculator</title>
 <meta name="description" content="Check World Rugby's test rankings and see what effect upcoming tests might have." />
-<meta name="viewport" content="width=480"/>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
 <script src="//cdn.rawgit.com/agschwender/jquery.formatDateTime/master/dist/jquery.formatDateTime.min.js"></script>

--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -151,6 +151,12 @@ table {
         flex-direction: row;
         overflow-x: hidden;
         flex: 1;
+        gap: 32px;
+        padding: 24px 32px 32px;
+        margin: 0 auto;
+        max-width: 1200px;
+        box-sizing: border-box;
+        align-items: stretch;
     }
     #footer {
         flex: 0;
@@ -193,6 +199,11 @@ table {
     #leftright {
         display: flex;
         flex-direction: column-reverse;
+        gap: 16px;
+        padding: 0 16px 24px;
+        box-sizing: border-box;
+        width: 100%;
+        overflow-x: hidden;
     }
     #left, #right {
         display: flex;
@@ -210,6 +221,8 @@ body {
 
 #leftright {
     @extend %white;
+    box-sizing: border-box;
+    width: 100%;
 }
 
 #footer {
@@ -219,7 +232,8 @@ body {
 }
 
 #left, #right {
-    .header { 
+    min-width: 0;
+    .header {
         @extend %primary;
 
         h3 {
@@ -284,6 +298,8 @@ body {
 
     table {
         margin: 0 auto;
+        width: 100%;
+        max-width: 100%;
         border-collapse: collapse;
 
         th {
@@ -326,6 +342,8 @@ body {
 
     table {
         margin: 0 auto;
+        width: 100%;
+        max-width: 100%;
         border-collapse: collapse;
 
         @include largescreen {


### PR DESCRIPTION
## Summary
- update the viewport meta tag to rely on device width and scaling
- adjust the main layout flex containers to add responsive padding and gaps while keeping small screens stacked
- stretch primary tables to the container width so content scales at narrow and wide breakpoints

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d149f776288328b47ac96201a631da