### PR TITLE
Remove RWC2023 event page

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,9 +25,6 @@
         <a data-bind="css: source == 'wru' ? 'sel' : '', attr: { href: $data.source == 'wru' ? null : '?s=wru' }">
             WRU
         </a>
-        <a data-bind="css: source == '1893' ? 'sel' : '', attr: { href: $data.source == '1893' ? null : '?s=1893' }">
-            RWC2023
-        </a>
     </div>
     <div id="leftright">
         <div id="left">

--- a/scripts/models/ViewModel.js
+++ b/scripts/models/ViewModel.js
@@ -1,6 +1,6 @@
 // Overall view model for the page
 var ViewModel = function (source) {
-    this.source = source; // mru or wru or event id - doesn't really matter, just goes back into the query
+    this.source = source; // mru or wru - doesn't really matter, just goes back into the query
     this.rankingsSource = ko.observable(source); // in the footer link - should end up as mru or wru
 
     // The base rankings in an object, indexed by the ID of the team.

--- a/scripts/wr-calc.js
+++ b/scripts/wr-calc.js
@@ -5,8 +5,10 @@ var usp = new URLSearchParams(s);
 var dateString = usp.get('d');
 var fixturesString = usp.get('f');
 
-var sourceString = usp.has('w') ? 'wru' : usp.get('s'); // support ?w for older links
-if (!sourceString) {
+var sourceString = 'mru';
+if (usp.has('w') || usp.get('s') === 'wru') { // support ?w for older links
+    sourceString = 'wru';
+} else if (usp.get('s') === 'mru') {
     sourceString = 'mru';
 }
 
@@ -81,20 +83,7 @@ var loadRankings = function (rankingsSource, startDate, fixtures, event) {
     });
 };
 
-if (sourceString == 'mru' || sourceString == 'wru') {
-    loadRankings(sourceString, dateString)
-} else {
-    // load the event!
-    $.get('https://api.wr-rims-prod.pulselive.com/rugby/v3/event/' + sourceString + '/schedule?language=en').done(function (data) {
-
-        loadRankings(
-            data.event.sport,
-            data.event.start.label,// maybe subtract a day so we don't include rankings on that date?
-            data.matches,
-            data.event
-        );
-    });
-}
+loadRankings(sourceString, dateString);
 
 // Helper to add a fixture to the top/bottom.
 // If we had up/down buttons we could maybe get rid of this.


### PR DESCRIPTION
## Summary
- remove the RWC2023 navigation option from the rankings calculator
- simplify source parsing so only MRU and WRU rankings are loaded
- update the ViewModel comment now that event ids are no longer supported

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d14bea85c4832882f53635236a421b