### PR TITLE
Prevent editing imported fixture teams

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,11 +93,11 @@
                         </tr>
                         <!-- /ko -->
                         <tr class="teams">
-                            <td colspan="2" style="text-align: left"><select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: homeId, optionsCaption: homeCaption, disabled: alreadyInRankings"></select></td colspan="2">
+                            <td colspan="2" style="text-align: left"><select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: homeId, optionsCaption: homeCaption, disabled: !$data.canEditTeams() || $data.alreadyInRankings"></select></td colspan="2">
                             <td colspan="4" class="outcome" style="text-align: center">
                                 <select data-bind="options: outcomeOptions, optionsText: 'label', optionsValue: 'value', optionsCaption: outcomeCaption, value: result, valueAllowUnset: true, disabled: alreadyInRankings"></select>
                             </td>
-                            <td colspan="2" style="text-align: right"><select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: awayId, optionsCaption: awayCaption, disabled: alreadyInRankings"></select></td colspan="2">
+                            <td colspan="2" style="text-align: right"><select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: awayId, optionsCaption: awayCaption, disabled: !$data.canEditTeams() || $data.alreadyInRankings"></select></td colspan="2">
                             <td>
                                 <input type="checkbox" data-bind="checked: noHome, disabled: alreadyInRankings" />
                                 <span data-bind="if: switched" title="Home team is nominally Away">*</span>

--- a/scripts/models/FixtureViewModel.js
+++ b/scripts/models/FixtureViewModel.js
@@ -22,6 +22,7 @@ var FixtureViewModel = function (parent) {
     this.liveScoreMode = null;
     this.kickoff = null;
     this.alreadyInRankings = false;
+    this.canEditTeams = ko.observable(true);
 
     // Placeholder captions used until teams are selected in the fixture row.
     this.homeCaption = 'Home...';

--- a/scripts/wr-calc.js
+++ b/scripts/wr-calc.js
@@ -162,6 +162,7 @@ var fixturesLoaded = function (fixtures, rankings) {
         addFixture(true, function (fixture) {
             fixture.homeId(e.teams[0].id);
             if (e.teams[1]) fixture.awayId(e.teams[1].id); // See ANC above
+            fixture.canEditTeams(false);
             fixture.noHome(false);
             fixture.switched(false);
             fixture.kickoff = $.formatDateTime('D dd/mm/yy hh:ii', new Date(e.time.millis));


### PR DESCRIPTION
## Summary
- add a view-model flag to track whether fixture teams can be edited
- disable home and away selectors for fixtures loaded from World Rugby so their teams stay unchanged

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d157920e848328bf04ca92af286ee6