### PR TITLE
Restyle fixture change indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,13 +107,52 @@
                         </tr>
                         <!-- ko if: $data.hasValidTeams() && !$data.alreadyInRankings -->
                         <tr class="possible-changes">
-                            <td class="details-left" data-bind="text: $data.homeRankingBefore() ? $data.homeRankingBefore().toFixed(2) : ''"></td>
-                            <td class="details-right" data-bind="text: $data.getDisplayChange(0), style: { 'text-decoration': $data.activeChange() == 0 ?  'underline' : 'inherit'}"></td class="details-center">
-                            <td class="details-center" data-bind="text: $data.getDisplayChange(1), style: { 'text-decoration': $data.activeChange() == 1 ?  'underline' : 'inherit'}"></td class="details-center">
-                            <td colspan="2" class="details-center" data-bind="text: $data.getDisplayChange(2), style: { 'text-decoration': $data.activeChange() == 2 ?  'underline' : 'inherit'}"></td class="details-center">
-                            <td class="details-center" data-bind="text: $data.getDisplayChange(3), style: { 'text-decoration': $data.activeChange() == 3 ?  'underline' : 'inherit'}"></td class="details-center">
-                            <td class="details-left" data-bind="text: $data.getDisplayChange(4), style: { 'text-decoration': $data.activeChange() == 4 ?  'underline' : 'inherit'}"></td class="details-center">
-                            <td class="details-right" data-bind="text: $data.awayRankingBefore() ? $data.awayRankingBefore().toFixed(2) : ''"></td>
+                            <td class="details-left">
+                                <span class="change-chip change-chip--rating" data-bind="text: $data.homeRankingBefore() != null ? $data.homeRankingBefore().toFixed(2) : ''"></span>
+                            </td>
+                            <td class="details-right">
+                                <span class="change-chip change-chip--delta" data-bind="text: $data.getDisplayChange(0), css: {
+                                    'change-chip--positive': $data.getChangeValue(0) > 0,
+                                    'change-chip--negative': $data.getChangeValue(0) < 0,
+                                    'change-chip--neutral': $data.getChangeValue(0) === 0,
+                                    'change-chip--active': $data.activeChange() === 0
+                                }"></span>
+                            </td>
+                            <td class="details-center">
+                                <span class="change-chip change-chip--delta" data-bind="text: $data.getDisplayChange(1), css: {
+                                    'change-chip--positive': $data.getChangeValue(1) > 0,
+                                    'change-chip--negative': $data.getChangeValue(1) < 0,
+                                    'change-chip--neutral': $data.getChangeValue(1) === 0,
+                                    'change-chip--active': $data.activeChange() === 1
+                                }"></span>
+                            </td>
+                            <td colspan="2" class="details-center">
+                                <span class="change-chip change-chip--delta" data-bind="text: $data.getDisplayChange(2), css: {
+                                    'change-chip--positive': $data.getChangeValue(2) > 0,
+                                    'change-chip--negative': $data.getChangeValue(2) < 0,
+                                    'change-chip--neutral': $data.getChangeValue(2) === 0,
+                                    'change-chip--active': $data.activeChange() === 2
+                                }"></span>
+                            </td>
+                            <td class="details-center">
+                                <span class="change-chip change-chip--delta" data-bind="text: $data.getDisplayChange(3), css: {
+                                    'change-chip--positive': $data.getChangeValue(3) > 0,
+                                    'change-chip--negative': $data.getChangeValue(3) < 0,
+                                    'change-chip--neutral': $data.getChangeValue(3) === 0,
+                                    'change-chip--active': $data.activeChange() === 3
+                                }"></span>
+                            </td>
+                            <td class="details-left">
+                                <span class="change-chip change-chip--delta" data-bind="text: $data.getDisplayChange(4), css: {
+                                    'change-chip--positive': $data.getChangeValue(4) > 0,
+                                    'change-chip--negative': $data.getChangeValue(4) < 0,
+                                    'change-chip--neutral': $data.getChangeValue(4) === 0,
+                                    'change-chip--active': $data.activeChange() === 4
+                                }"></span>
+                            </td>
+                            <td class="details-right">
+                                <span class="change-chip change-chip--rating" data-bind="text: $data.awayRankingBefore() != null ? $data.awayRankingBefore().toFixed(2) : ''"></span>
+                            </td>
                             <td colspan="3"></td>
                         </tr>
                         <!-- /ko -->

--- a/scripts/models/FixtureViewModel.js
+++ b/scripts/models/FixtureViewModel.js
@@ -81,17 +81,30 @@ var FixtureViewModel = function (parent) {
         ];
     }, this);
 
-    this.getDisplayChange = function(index) {
+    this.getChangeValue = function (index) {
         var changes = this.changes();
-        if (!changes) return null;
+        if (!changes) {
+            return null;
+        }
+
         var change = changes[index];
-        if (isNaN(change)) return null;
+        if (isNaN(change)) {
+            return null;
+        }
+
+        return change;
+    };
+
+    this.getDisplayChange = function(index) {
+        var change = this.getChangeValue(index);
+        if (change === null) {
+            return '';
+        }
 
         var formattedChange = Math.abs(change).toFixed(2);
-        var prefix = change > 0 ? '<' : '';
-        var suffix = change < 0 ? '>' : '';
+        var prefix = change > 0 ? '+' : change < 0 ? '−' : '';
 
-        return prefix + formattedChange + suffix;
+        return prefix + formattedChange;
     };
 
     this.activeChange = ko.computed(function () {

--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -402,8 +402,11 @@ body {
             margin-bottom: (56px / 2) + 2px;
         }
 
-        tr.details td, tr.possible-changes td {
-            font-size: 9px;
+        tr.details td {
+            font-size: 11px;
+            padding: 6px 4px;
+            color: rgba($black, 0.6);
+
             &.details-left {
                 text-align: left;
             }
@@ -412,6 +415,78 @@ body {
             }
             &.details-right {
                 text-align: right;
+            }
+        }
+
+        tr.possible-changes {
+            background-color: lighten($primary-1, 52%);
+        }
+
+        tr.possible-changes td {
+            padding: 12px 4px 14px;
+            vertical-align: top;
+            font-size: 12px;
+            color: rgba($black, 0.65);
+
+            &.details-left {
+                text-align: left;
+            }
+            &.details-center {
+                text-align: center;
+            }
+            &.details-right {
+                text-align: right;
+            }
+        }
+
+        tr.possible-changes td .change-chip {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 56px;
+            padding: 6px 12px;
+            font-size: 12px;
+            font-weight: 500;
+            line-height: 1.1;
+            border-radius: 999px;
+            letter-spacing: 0.01em;
+            background-color: rgba($white, 0.9);
+            box-shadow: 0 2px 4px rgba($black, 0.12);
+            color: rgba($black, 0.64);
+            transition: background-color 0.15s ease-in-out, color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+
+            &.change-chip--rating {
+                min-width: auto;
+                padding: 6px 10px;
+                background-color: lighten($primary-1, 36%);
+                color: rgba($black, 0.72);
+                font-weight: 600;
+            }
+
+            &.change-chip--delta {
+                background-color: lighten($primary-1, 42%);
+            }
+
+            &.change-chip--positive {
+                background-color: rgba($primary-2, 0.16);
+                color: $primary-2;
+            }
+
+            &.change-chip--negative {
+                background-color: rgba($accent, 0.18);
+                color: $accent;
+            }
+
+            &.change-chip--neutral {
+                background-color: lighten($primary-1, 38%);
+            }
+
+            &.change-chip--active {
+                box-shadow: 0 0 0 2px rgba($primary-2, 0.25);
+            }
+
+            &:empty {
+                display: none;
             }
         }
 


### PR DESCRIPTION
## Summary
- replace the tiny ranking-change numbers with styled chips that sit in line with the fixture selections
- add positive/negative/neutral colouring and active highlighting to make the outcomes easier to read
- expose change values in the view model so the new styling logic can react to positives, negatives and draws

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d157bd63f083289c89228b3fecb07e