### PR TITLE
Prevent toggling NHA and RWC checkboxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,10 +99,10 @@
                             </td>
                             <td colspan="2" style="text-align: right"><select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: awayId, optionsCaption: awayCaption, disabled: !$data.canEditTeams() || $data.alreadyInRankings"></select></td colspan="2">
                             <td>
-                                <input type="checkbox" data-bind="checked: noHome, disabled: alreadyInRankings" />
+                                <input type="checkbox" data-bind="checked: noHome, click: preventCheckboxToggle, event: { keydown: preventCheckboxToggle }" />
                                 <span data-bind="if: switched" title="Home team is nominally Away">*</span>
                             </td>
-                            <td><input type="checkbox" data-bind="checked: isRwc, disabled: alreadyInRankings" /></td>
+                            <td><input type="checkbox" data-bind="checked: isRwc, click: preventCheckboxToggle, event: { keydown: preventCheckboxToggle }" /></td>
                             <td><button data-bind="click: function () { $parent.fixtures.remove($data); }, disabled: alreadyInRankings">x</button></td>
                         </tr>
                         <!-- ko if: $data.hasValidTeams() && !$data.alreadyInRankings -->

--- a/scripts/models/FixtureViewModel.js
+++ b/scripts/models/FixtureViewModel.js
@@ -121,5 +121,18 @@ var FixtureViewModel = function (parent) {
         return result;
     }, this);
 
+    this.preventCheckboxToggle = function (_, event) {
+        if (event) {
+            if (typeof event.preventDefault === 'function') {
+                event.preventDefault();
+            }
+            if (typeof event.stopPropagation === 'function') {
+                event.stopPropagation();
+            }
+        }
+
+        return false;
+    };
+
     return this;
 };


### PR DESCRIPTION
## Summary
- stop users from toggling the NHA and RWC values while keeping the current checkmark visible
- add a shared handler on fixtures to block mouse and keyboard input from altering the checkbox state

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d15da152d083289271e704cbfab3fd