### PR TITLE
Expand layout width and balance rankings and fixtures

### DIFF
--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -153,9 +153,9 @@ table {
         overflow-x: hidden;
         flex: 1;
         gap: 32px;
-        padding: 24px 32px 32px;
+        padding: 24px 24px 32px;
         margin: 0 auto;
-        max-width: 1200px;
+        max-width: 1440px;
         box-sizing: border-box;
         align-items: stretch;
 
@@ -166,7 +166,7 @@ table {
     #left {
         @include height(6);
         height: 100%;
-        flex: 0.5;
+        flex: 0 1 40%;
         display: flex;
         flex-direction: column;
     }
@@ -175,7 +175,7 @@ table {
         height: 100%;
         display: flex;
         flex-direction: column;
-        flex: 1;
+        flex: 0 1 60%;
     }
     #left, #right {
     .header h3 {
@@ -226,9 +226,9 @@ body {
     @extend %white;
     background-color: transparent;
     width: 100%;
-    max-width: 1200px;
+    max-width: 1440px;
     margin: 0 auto;
-    padding: 24px;
+    padding: 24px 16px;
     gap: 24px;
 }
 


### PR DESCRIPTION
## Summary
- expand the maximum width available to the two-column layout and trim horizontal padding to use more of the screen
- adjust the rankings column to occupy 40% of the layout with fixtures using the remaining 60%

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d15ddeece083288f34ec01332da489