### PR TITLE
Widen fixture outcome selector

### DIFF
--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -452,8 +452,19 @@ body {
             width: 3em;
         }
 
-        td.outcome select {
-            width: 100%;
+        td.outcome {
+            min-width: 220px;
+
+            @include smallscreen {
+                min-width: 0;
+            }
+
+            select {
+                width: 100%;
+                min-height: 64px;
+                padding: 12px 16px;
+                box-sizing: border-box;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure fixture outcome column reserves more space so the selector appears wider
- increase the selector height so the control is twice as tall for easier tapping

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d1577102308328974c0102796c713d