### PR TITLE
Remove outcome point values from fixture panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,6 @@
                                     <div class="fixture-change-panel__outcomes" data-bind="foreach: $data.outcomeOptions">
                                         <div class="change-chip" data-bind="css: $parent.getChangeClasses($index())">
                                             <span class="change-chip__label" data-bind="text: label"></span>
-                                            <span class="change-chip__value" data-bind="text: $parent.getChangeDisplay($index())"></span>
                                         </div>
                                     </div>
                                     <div class="fixture-change-panel__team fixture-change-panel__team--away">

--- a/scripts/models/FixtureViewModel.js
+++ b/scripts/models/FixtureViewModel.js
@@ -102,25 +102,6 @@ var FixtureViewModel = function (parent) {
         return change;
     };
 
-
-    this.getChangeDisplay = function (index) {
-        var change = self.getChangeValue(index);
-
-        if (change === null) {
-            return '—';
-        }
-
-        var formatted = Math.abs(change).toFixed(2);
-        if (change > 0) {
-            return '+' + formatted;
-        }
-        if (change < 0) {
-            return '-' + formatted;
-        }
-
-        return formatted;
-    };
-
     this.getChangeClasses = function (index) {
         var change = self.getChangeValue(index);
         var isActive = typeof self.activeChange === 'function' && self.activeChange() === index;

--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -525,18 +525,8 @@ body {
             color: rgba($black, 0.54);
         }
 
-        .change-chip__value {
-            font-size: 20px;
-            font-weight: 500;
-            color: rgba($black, 0.87);
-        }
-
         .change-chip--positive {
             background: lighten($primary-1, 35%);
-        }
-
-        .change-chip--positive .change-chip__value {
-            color: $primary-2;
         }
 
         .change-chip--positive .change-chip__label {
@@ -545,10 +535,6 @@ body {
 
         .change-chip--negative {
             background: lighten($accent, 45%);
-        }
-
-        .change-chip--negative .change-chip__value {
-            color: $accent;
         }
 
         .change-chip--negative .change-chip__label {


### PR DESCRIPTION
## Summary
- remove the numeric change display from each fixture outcome chip
- delete the unused change formatting helper in the fixture view model
- clean up styling that was specific to the removed change values

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d165786ed88328b6469fb9d951a72f