### PR TITLE
Restore flexible growth for rankings and fixtures columns

### DIFF
--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -167,7 +167,7 @@ table {
         @include height(6);
         height: 100%;
 
-        flex: 0 1 40%;
+        flex: 1 1 40%;
         display: flex;
         flex-direction: column;
     }
@@ -176,7 +176,7 @@ table {
         height: 100%;
         display: flex;
         flex-direction: column;
-        flex: 0 1 60%;
+        flex: 1 1 60%;
     }
     #left, #right {
     .header h3 {


### PR DESCRIPTION
## Summary
- allow the rankings and fixtures columns to keep the 40/60 split while still growing to accommodate their content
- prevent the layout constraint introduced in PR #16 from shrinking the tables when additional width is available

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68d1655ac3588328bd5603b63f2d47cb