### PR TITLE
Fix invalid SCSS block for add row styling

### DIFF
--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -612,14 +612,13 @@ body {
 #addrow {
     position: relative;
 
+    td.outcome {
+        @include smallscreen {
+            min-width: 0;
+        }
 
-            @include smallscreen {
-                min-width: 0;
-            }
-
-            select {
-                width: 100%;
-            }
+        select {
+            width: 100%;
         }
     }
 }


### PR DESCRIPTION
## Summary
- restructure the `#addrow` section in `styles/wr-calc.scss` so it contains a valid selector hierarchy
- keep the responsive rules for the add-row outcome cell while removing stray braces that broke compilation

## Testing
- `bundle exec jekyll build` *(fails: bundler could not install gems because rubygems.org returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68d167007de083288e52528634e34adf