### PR TITLE
Remove fixture outcome chips from change panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,11 +116,6 @@
                                         <span class="fixture-change-panel__label">Home rating</span>
                                         <span class="fixture-change-panel__value" data-bind="text: $data.homeRankingBefore() ? $data.homeRankingBefore().toFixed(2) : '—'"></span>
                                     </div>
-                                    <div class="fixture-change-panel__outcomes" data-bind="foreach: $data.outcomeOptions">
-                                        <div class="change-chip" data-bind="css: $parent.getChangeClasses($index())">
-                                            <span class="change-chip__label" data-bind="text: label"></span>
-                                        </div>
-                                    </div>
                                     <div class="fixture-change-panel__team fixture-change-panel__team--away">
                                         <span class="fixture-change-panel__label">Away rating</span>
                                         <span class="fixture-change-panel__value" data-bind="text: $data.awayRankingBefore() ? $data.awayRankingBefore().toFixed(2) : '—'"></span>

--- a/scripts/models/FixtureViewModel.js
+++ b/scripts/models/FixtureViewModel.js
@@ -83,48 +83,6 @@ var FixtureViewModel = function (parent) {
         ];
     }, this);
 
-    this.getChangeValue = function (index) {
-
-        var changes = self.changes();
-        if (!changes || typeof index === 'undefined') {
-
-   
-
-            return null;
-        }
-
-        var change = changes[index];
-
-        if (typeof change !== 'number' || isNaN(change)) {
-            return null;
-        }
-
-        return change;
-    };
-
-    this.getChangeClasses = function (index) {
-        var change = self.getChangeValue(index);
-        var isActive = typeof self.activeChange === 'function' && self.activeChange() === index;
-        var classes = {
-            'change-chip--active': isActive
-        };
-
-        if (change === null) {
-            classes['change-chip--empty'] = true;
-            return classes;
-        }
-
-        if (change > 0) {
-            classes['change-chip--positive'] = true;
-        } else if (change < 0) {
-            classes['change-chip--negative'] = true;
-        } else {
-            classes['change-chip--neutral'] = true;
-        }
-
-        return classes;
-    };
-
     this.activeChange = ko.computed(function () {
         if (!this.isValid()) {
             return null;

--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -497,63 +497,6 @@ body {
             color: rgba($black, 0.87);
         }
 
-        .fixture-change-panel__outcomes {
-            flex: 1 1 320px;
-            display: flex;
-            flex-wrap: wrap;
-            justify-content: center;
-            gap: 12px;
-        }
-
-        .change-chip {
-            min-width: 130px;
-            padding: 14px 18px;
-            border-radius: 999px;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 6px;
-            background: lighten($primary-1, 42%);
-            box-shadow: 0 4px 12px rgba($black, 0.05);
-            transition: box-shadow 0.2s ease-in-out, transform 0.2s ease-in-out;
-        }
-
-        .change-chip__label {
-            font-size: 11px;
-            letter-spacing: 0.06em;
-            text-transform: uppercase;
-            color: rgba($black, 0.54);
-        }
-
-        .change-chip--positive {
-            background: lighten($primary-1, 35%);
-        }
-
-        .change-chip--positive .change-chip__label {
-            color: rgba($primary-2, 0.75);
-        }
-
-        .change-chip--negative {
-            background: lighten($accent, 45%);
-        }
-
-        .change-chip--negative .change-chip__label {
-            color: rgba($accent, 0.75);
-        }
-
-        .change-chip--neutral {
-            background: lighten($primary-1, 45%);
-        }
-
-        .change-chip--active {
-            box-shadow: 0 10px 24px rgba($black, 0.15);
-            transform: translateY(-2px);
-        }
-
-        .change-chip--empty {
-            opacity: 0.45;
-        }
-
         th, td {
             padding: 0 4px;
         }


### PR DESCRIPTION
## Summary
- stop rendering the fixture outcome chips so users can no longer see the possible results in the change panel
- remove the associated view-model helpers and styles that only supported the chips

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d1684c0b84832886d0da0d41b48cdc