### PR TITLE
Limit fixture outcome select width

### DIFF
--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -544,9 +544,14 @@ body {
 
             select {
                 width: 100%;
+                max-width: 220px;
                 min-height: 64px;
                 padding: 12px 16px;
                 box-sizing: border-box;
+
+                @include smallscreen {
+                    max-width: none;
+                }
             }
         }
     }
@@ -562,6 +567,11 @@ body {
 
         select {
             width: 100%;
+            max-width: 220px;
+
+            @include smallscreen {
+                max-width: none;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- cap fixture outcome select inputs to their previous 220px maximum while keeping them responsive on small screens
- mirror the width cap for the add-row outcome selector

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d16abc2d6c83289be6f467ec153c52