### PR TITLE
Increase base font sizing for readability

### DIFF
--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -82,34 +82,29 @@ $accent: #dd2c00;
  */
 body {
     font-family: 'Roboto', sans-serif;
-    font-size: 13px;
+    font-size: 16px;
     font-weight: 400;
 }
 h3 {
-    font-size: 20px;
+    font-size: 24px;
     font-weight: 500;
 }
 table {
     th {
-        font-size: 12px;
+        font-size: 14px;
         font-weight: 500;
     }
     td {
-        font-size: 13px;
+        font-size: 16px;
         font-weight: 400;
-        input, select {
-            font-size: 13px !important;
-            font-weight: 400 !important;
-            font-family: 'Roboto', sans-serif !important;
-        }
     }
 }
 #which, #union {
-    font-size: 14px;
+    font-size: 18px;
     font-weight: 500;
 }
 #footer { // can't really find a material match for this
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 400;
 }
 


### PR DESCRIPTION
## Summary
- raise the base body font size to 16px and scale related headings, table headers, and footer text for a clearer hierarchy
- remove the table cell form control font overrides so inputs and selects inherit the new sizing

## Testing
- bundle install *(fails: Gem::Net::HTTPClientException 403 "Forbidden" while fetching from rubygems.org)*

------
https://chatgpt.com/codex/tasks/task_b_68d24375bcf88328a5ee0a84c7b522c5