### PR TITLE
Revamp segmented controls for rankings selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,13 +18,21 @@
 <script src="scripts/models/FixtureViewModel.js?v={{site.time|date:'%s'}}" type="text/javascript" ></script>
 </head>
 <body>
-    <div id="union">
-        <a data-bind="css: source == 'mru' ? 'sel' : '', attr: { href: $data.source == 'mru' ? null : '?s=mru' }">
-            Men's
-        </a>
-        <a data-bind="css: source == 'wru' ? 'sel' : '', attr: { href: $data.source == 'wru' ? null : '?s=wru' }">
-            Women's
-        </a>
+    <div id="union" class="segmented-control" role="group" aria-label="Select rankings competition">
+        <button type="button"
+            class="segmented-control__segment"
+            data-bind="css: { 'segmented-control__segment--active': source == 'mru' },
+                       attr: { 'aria-pressed': source == 'mru' },
+                       click: function () { if ($data.source !== 'mru') { window.location.search = '?s=mru'; } }">
+            <span class="segmented-control__label">Men's</span>
+        </button>
+        <button type="button"
+            class="segmented-control__segment"
+            data-bind="css: { 'segmented-control__segment--active': source == 'wru' },
+                       attr: { 'aria-pressed': source == 'wru' },
+                       click: function () { if ($data.source !== 'wru') { window.location.search = '?s=wru'; } }">
+            <span class="segmented-control__label">Women's</span>
+        </button>
     </div>
     <div id="leftright">
         <div id="left">
@@ -32,14 +40,26 @@
                 <h3>Rankings</h3>
             </div>
             <div id="which" data-bind="if: rankingsChoice">
-                <label data-bind="css: $data.rankingsChoice() === 'original' ? 'sel' : ''">
-                    <input type="radio" name="rankings" value="original" data-bind="checked: rankingsChoice">
-                    <span data-bind="text: $data.originalDate() + ($data.originalDateIsEstimated() ? '*' : ''), title: $data.originalDateIsEstimated() ? 'Last published rankings on or before this date' : ''" />
-                </label>
-                <label data-bind="css: $data.rankingsChoice() === 'calculated' ? 'sel' : ''">
-                    <input type="radio" name="rankings" value="calculated" data-bind="checked: rankingsChoice">
-                    CALCULATED
-                </label>
+                <div class="segmented-control segmented-control--block">
+                    <fieldset class="segmented-control__fieldset" role="radiogroup" aria-label="Choose rankings to display">
+                        <legend class="visually-hidden">Rankings to display</legend>
+                        <label class="segmented-control__segment"
+                            data-bind="css: { 'segmented-control__segment--active': $data.rankingsChoice() === 'original' }">
+                            <input class="segmented-control__input" type="radio" name="rankings" value="original" data-bind="checked: rankingsChoice">
+                            <span class="segmented-control__content">
+                                <span class="segmented-control__label"
+                                    data-bind="text: $data.originalDate() + ($data.originalDateIsEstimated() ? '*' : ''), title: $data.originalDateIsEstimated() ? 'Last published rankings on or before this date' : ''"></span>
+                            </span>
+                        </label>
+                        <label class="segmented-control__segment"
+                            data-bind="css: { 'segmented-control__segment--active': $data.rankingsChoice() === 'calculated' }">
+                            <input class="segmented-control__input" type="radio" name="rankings" value="calculated" data-bind="checked: rankingsChoice">
+                            <span class="segmented-control__content">
+                                <span class="segmented-control__label">CALCULATED</span>
+                            </span>
+                        </label>
+                    </fieldset>
+                </div>
             </div>
 
             <div id="rankings">

--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -85,6 +85,17 @@ body {
     font-size: 13px;
     font-weight: 400;
 }
+.visually-hidden {
+    position: absolute !important;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    border: 0;
+}
 h3 {
     font-size: 20px;
     font-weight: 500;
@@ -253,64 +264,134 @@ body {
     }
 }
 
-#which {
-    display: flex;
-    @extend %primary;
-
-    height: 48px;
-    line-height: 48px;
-    width: 100%;
-
-    label {
-        flex-grow: 1;
-        text-align: center;
-        border-bottom: 2px solid $primary;
-
-        &.sel {
-            border-bottom-color: $accent;
-        }
-        &:not(.sel) {
-            @extend .secondaryText;
-        }
-
-        input {
-            display: none;
-        }
-    }
-}
-
-#union {
+.segmented-control {
     display: inline-flex;
-    align-items: center;
+    align-items: stretch;
     justify-content: center;
-    margin: 24px auto 0;
+    gap: 4px;
     padding: 4px;
     border-radius: 999px;
     background-color: lighten($primary-1, 35%);
     box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
-    gap: 4px;
 
-    a {
+    &--block {
+        width: 100%;
+    }
+
+    &__fieldset {
         display: flex;
+        flex: 1;
+        border: 0;
+        margin: 0;
+        padding: 0;
+        min-width: 0;
+    }
+
+    &__segment {
+        position: relative;
+        display: inline-flex;
         align-items: center;
         justify-content: center;
+        gap: 8px;
+        flex: 1 1 auto;
+        min-height: 44px;
         min-width: 88px;
-        padding: 6px 18px;
+        padding: 0 18px;
+        border: 0;
         border-radius: 999px;
+        background: transparent;
+        color: rgba($black, 0.6);
+        font-size: 14px;
+        font-weight: 500;
         text-decoration: none;
-        color: rgba($black, 0.54);
-        transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+        cursor: pointer;
+        transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out, color 0.2s ease-in-out;
 
-        &:hover,
-        &:focus {
+        &:hover {
             color: rgba($black, 0.87);
         }
 
-        &.sel {
-            background-color: $white;
-            color: rgba($black, 0.87);
-            box-shadow: inset 0 0 0 1px rgba($primary-2, 0.3);
+        &:focus-visible,
+        &:focus-within {
+            outline: none;
+            box-shadow: 0 0 0 2px rgba($primary-2, 0.35);
         }
+
+        &:active {
+            transform: translateY(1px);
+        }
+    }
+
+    &__segment--active {
+        background-color: $white;
+        color: rgba($black, 0.87);
+        box-shadow: inset 0 0 0 1px rgba($primary-2, 0.25), 0 2px 6px rgba($primary-2, 0.2);
+    }
+
+    &__input {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+        padding: 0;
+        border: 0;
+        clip: rect(0, 0, 0, 0);
+        clip-path: inset(50%);
+        overflow: hidden;
+    }
+
+    &__content {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+    }
+
+    &__label {
+        white-space: nowrap;
+    }
+
+    &__icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 18px;
+        height: 18px;
+
+        svg {
+            width: 100%;
+            height: 100%;
+        }
+    }
+
+    label&__segment {
+        min-width: 0;
+    }
+
+    button&__segment {
+        appearance: none;
+        background-color: transparent;
+    }
+}
+
+#which {
+    margin-bottom: 16px;
+
+    .segmented-control {
+        display: flex;
+    }
+
+    .segmented-control__segment {
+        height: 48px;
+        line-height: 1.3;
+    }
+}
+
+#union {
+    margin: 24px auto 0;
+
+    .segmented-control__segment {
+        flex: 0 0 auto;
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the union switcher anchors with accessible segmented control buttons
- rebuild the rankings selector markup so each option sits in a labelled segmented control
- add reusable segmented-control styling with pill segments, focus outlines, and optional icon support

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d2437a28188328bfa47eedbae3ebc9