### PR TITLE
Refactor fixtures into card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,103 +72,68 @@
                 <h3>Fixtures</h3>
             </div>
             <div id="fixtures">
-                <table>
-                    <thead>
-                        <tr>
-                            <th colspan="2">Home team</th>
-                            <th colspan="4">Outcome</th>
-                            <th colspan="2">Away team</th>
-                            <th title='No Home Advantage'>NHA</th>
-                            <th title='Is Rugby World Cup match'>RWC</th>
-                    </tr>
-                    </thead>
+                <div class="fixtures-list">
                     <!-- ko foreach: fixtures -->
-                    <tbody class="fixture">
+                    <div class="fixture-card">
                         <!-- ko if: $data.venueNameAndCountry || $data.kickoff || $data.liveScoreMode || $data.eventPhase -->
-                        <tr class="details">
-                            <td class="details-left" colspan="2" data-bind="text: kickoff" title="Kickoff in your browser time"></td>
-                            <td class="details-center" colspan="4" data-bind="text: ($data.eventPhase && $data.liveScoreMode) ? ($data.eventPhase + ' (' + $data.liveScoreMode + ')') : ($data.eventPhase || $data.liveScoreMode)"></td>
-                            <td class="details-right" colspan="4" data-bind="text: venueNameAndCountry, title: venueCity"></td>
-                        </tr>
+                        <div class="fixture-card__meta">
+                            <div class="fixture-card__meta-item fixture-card__meta-item--kickoff" data-bind="text: kickoff" title="Kickoff in your browser time"></div>
+                            <div class="fixture-card__meta-item fixture-card__meta-item--phase" data-bind="text: ($data.eventPhase && $data.liveScoreMode) ? ($data.eventPhase + ' (' + $data.liveScoreMode + ')') : ($data.eventPhase || $data.liveScoreMode)"></div>
+                            <div class="fixture-card__meta-item fixture-card__meta-item--venue" data-bind="text: venueNameAndCountry, attr: { title: venueCity }"></div>
+                        </div>
                         <!-- /ko -->
-                        <tr class="teams">
-                            <td colspan="2" style="text-align: left">
-                                <select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: homeId, optionsCaption: homeCaption, disabled: !$data.canEditTeams() || $data.alreadyInRankings">
-                                
-                            </select>
-                            </td colspan="2">
-                            <td colspan="4" class="outcome" style="text-align: center">
-                                <select data-bind="options: outcomeOptions, optionsText: 'label', optionsValue: 'value', optionsCaption: outcomeCaption, value: result, valueAllowUnset: true, disabled: alreadyInRankings">
-                                    
-                                </select>
-                            </td>
-                            <td colspan="2" style="text-align: right">
-                                <select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: awayId, optionsCaption: awayCaption, disabled: !$data.canEditTeams() || $data.alreadyInRankings">
-                                
-                            </select>
-                            </td colspan="2">
-                            <td>
-                                <input type="checkbox" data-bind="checked: noHome, click: preventCheckboxToggle, event: { keydown: preventCheckboxToggle }" />
-                                <span data-bind="if: switched" title="Home team is nominally Away">*</span>
-                            </td>
-
-                            <td>
-                                <input type="checkbox" data-bind="checked: isRwc, click: preventCheckboxToggle, event: { keydown: preventCheckboxToggle }" />
-                            </td>
-                            <td>
-                            </td>
-                        
-
-                        </tr>
-                        <!-- ko if: $data.hasValidTeams() && !$data.alreadyInRankings -->
-
-                        <tr class="possible-changes possible-changes--panel">
-                            <td colspan="11">
-                                <div class="fixture-change-panel">
-                                    <div class="fixture-change-panel__team fixture-change-panel__team--home">
-                                        <span class="fixture-change-panel__label">Home rating</span>
-                                        <span class="fixture-change-panel__value" data-bind="text: $data.homeRankingBefore() ? $data.homeRankingBefore().toFixed(2) : '—'"></span>
-                                    </div>
-                                    <div class="fixture-change-panel__team fixture-change-panel__team--away">
-                                        <span class="fixture-change-panel__label">Away rating</span>
-                                        <span class="fixture-change-panel__value" data-bind="text: $data.awayRankingBefore() ? $data.awayRankingBefore().toFixed(2) : '—'"></span>
-                                    </div>
+                        <div class="fixture-card__content">
+                            <div class="fixture-card__section fixture-card__section--teams">
+                                <div class="fixture-card__team fixture-card__team--home">
+                                    <span class="fixture-card__label">Home team</span>
+                                    <select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: homeId, optionsCaption: homeCaption, disabled: !$data.canEditTeams() || $data.alreadyInRankings"></select>
                                 </div>
-                            </td>
-                        </tr>
+                                <div class="fixture-card__outcome">
+                                    <span class="fixture-card__label">Outcome</span>
+                                    <select data-bind="options: outcomeOptions, optionsText: 'label', optionsValue: 'value', optionsCaption: outcomeCaption, value: result, valueAllowUnset: true, disabled: alreadyInRankings"></select>
+                                </div>
+                                <div class="fixture-card__team fixture-card__team--away">
+                                    <span class="fixture-card__label">Away team</span>
+                                    <select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: awayId, optionsCaption: awayCaption, disabled: !$data.canEditTeams() || $data.alreadyInRankings"></select>
+                                </div>
+                            </div>
+                            <div class="fixture-card__section fixture-card__section--flags">
+                                <span class="fixture-card__label">Flags</span>
+                                <div class="fixture-card__flags">
+                                    <label class="fixture-card__flag" title="No Home Advantage">
+                                        <input type="checkbox" data-bind="checked: noHome, click: preventCheckboxToggle, event: { keydown: preventCheckboxToggle }" />
+                                        <span class="fixture-card__flag-text">NHA</span>
+                                        <span class="fixture-card__flag-note" data-bind="if: switched" title="Home team is nominally Away">*</span>
+                                    </label>
+                                    <label class="fixture-card__flag" title="Is Rugby World Cup match">
+                                        <input type="checkbox" data-bind="checked: isRwc, click: preventCheckboxToggle, event: { keydown: preventCheckboxToggle }" />
+                                        <span class="fixture-card__flag-text">RWC</span>
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- ko if: $data.hasValidTeams() && !$data.alreadyInRankings -->
+                        <div class="possible-changes possible-changes--panel">
+                            <div class="fixture-change-panel">
+                                <div class="fixture-change-panel__team fixture-change-panel__team--home">
+                                    <span class="fixture-change-panel__label">Home rating</span>
+                                    <span class="fixture-change-panel__value" data-bind="text: $data.homeRankingBefore() ? $data.homeRankingBefore().toFixed(2) : '—'"></span>
+                                </div>
+                                <div class="fixture-change-panel__team fixture-change-panel__team--away">
+                                    <span class="fixture-change-panel__label">Away rating</span>
+                                    <span class="fixture-change-panel__value" data-bind="text: $data.awayRankingBefore() ? $data.awayRankingBefore().toFixed(2) : '—'"></span>
+                                </div>
+                            </div>
+                        </div>
                         <!-- /ko -->
                         <!-- ko if: alreadyInRankings -->
-                        <tr class="possible-changes possible-changes--message">
-                            <td colspan="8" class="details-center" title="The match is complete and kicked off 90 minutes or more before the latest rankings, so assume it is already included">Already ranked*</td>
-
-                            <td colspan="3"></td>
-                        </tr>
+                        <div class="possible-changes possible-changes--message">
+                            <div class="possible-changes__text" title="The match is complete and kicked off 90 minutes or more before the latest rankings, so assume it is already included">Already ranked*</div>
+                        </div>
                         <!-- /ko -->
-                    </tbody>
+                    </div>
                     <!-- /ko -->
-                    <!--
-                        trying to be clever and align the score cells like
-                        | HOME | AWAY |
-                        | <1 | 0 | 1> |
-                        by making this 2+2 and 1+2+1
-                        but Chrome seems to not want to align like this if no row has 4 cells there
-                        so we have to make an empty row with this many cells
-                    -->
-                    <tfoot aria-hidden="true">
-                        <tr>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                            <td></td>
-                        </tr>
-                    </tfoot>
-                </table>
+                </div>
             </div>
         </div>
     </div>

--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -397,158 +397,203 @@ body {
 #fixtures {
     padding: 10px 2px 0;
 
-    table {
-        margin: 0 auto;
-        width: 100%;
-        max-width: 100%;
-        border-collapse: collapse;
+    .fixtures-list {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
 
-        @include largescreen {
-            margin-bottom: 24px + 56px + 2px;
+    .fixture-card {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        background: $white;
+        border-radius: 16px;
+        border: 1px solid lighten($primary-1, 35%);
+        box-shadow: 0 10px 24px rgba($black, 0.08);
+        padding: 16px;
+    }
+
+    .fixture-card__meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px 16px;
+        font-size: 11px;
+        color: rgba($black, 0.54);
+
+        .fixture-card__meta-item {
+            flex: 1 1 160px;
         }
-        @include smallscreen {
-            margin-bottom: (56px / 2) + 2px;
-        }
+    }
 
-        tr.details td {
-            font-size: 9px;
-            &.details-left {
-                text-align: left;
-            }
-            &.details-center {
-                text-align: center;
-            }
-            &.details-right {
-                text-align: right;
-            }
-        }
+    .fixture-card__meta-item--kickoff {
+        text-align: left;
+    }
 
+    .fixture-card__meta-item--phase {
+        text-align: center;
+    }
 
-        td.details-left {
+    .fixture-card__meta-item--venue {
+        text-align: right;
+    }
+
+    @include smallscreen {
+        .fixture-card__meta-item--phase,
+        .fixture-card__meta-item--venue {
             text-align: left;
         }
+    }
 
-        td.details-center {
-            text-align: center;
+    .fixture-card__content {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+    }
+
+    .fixture-card__section {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .fixture-card__section--teams {
+        gap: 12px;
+
+        @include largescreen {
+            flex-direction: row;
+            align-items: flex-end;
         }
 
-        td.details-right {
-            text-align: right;
-        }
-
-        tr.possible-changes {
-            background-color: transparent !important;
-        }
-
-        tr.possible-changes--panel td {
-            padding: 0;
-            border-top: none;
-            border-bottom: none;
-        }
-
-        tr.possible-changes--message td {
-            font-size: 11px;
-            padding: 6px 4px;
-        }
-
-        .fixture-change-panel {
-            display: flex;
-            flex-wrap: wrap;
-            align-items: stretch;
-            justify-content: center;
-            gap: 12px;
-            background: lighten($primary-1, 48%);
-            border-radius: 16px;
-            padding: 16px;
-            box-shadow: 0 6px 18px rgba($black, 0.08);
-            width: 100%;
-        }
-
-        .fixture-change-panel__team {
-            flex: 0 0 auto;
-            min-width: 120px;
-            text-align: center;
-            border-radius: 12px;
-            padding: 12px 16px;
+        .fixture-card__team,
+        .fixture-card__outcome {
             display: flex;
             flex-direction: column;
             gap: 6px;
-            box-shadow: 0 4px 12px rgba($black, 0.06);
+            flex: 1 1 0;
         }
 
-        .fixture-change-panel__team--home {
-            background: lighten($primary-1, 36%);
+        .fixture-card__outcome {
+            flex: 1.2 1 0;
         }
 
-        .fixture-change-panel__team--away {
-            background: lighten($primary-1, 42%);
+        select {
+            width: 100%;
+            min-height: 56px;
+            padding: 12px 16px;
+            border-radius: 12px;
+            border: 1px solid lighten($primary-1, 30%);
+            background: lighten($primary-1, 55%);
+            box-sizing: border-box;
         }
+    }
 
-        .fixture-change-panel__label {
-            font-size: 11px;
-            text-transform: uppercase;
-            letter-spacing: 0.08em;
-            color: rgba($black, 0.54);
+    .fixture-card__label {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: rgba($black, 0.54);
+    }
+
+    .fixture-card__section--flags {
+        .fixture-card__label {
+            margin-bottom: 4px;
         }
+    }
 
-        .fixture-change-panel__value {
-            font-size: 22px;
-            font-weight: 500;
-            color: rgba($black, 0.87);
+    .fixture-card__flags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+    }
+
+    .fixture-card__flag {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 8px 12px;
+        border-radius: 999px;
+        background: lighten($primary-1, 48%);
+        box-shadow: inset 0 0 0 1px lighten($primary-1, 35%);
+        font-size: 12px;
+        color: rgba($black, 0.7);
+        cursor: pointer;
+
+        input {
+            margin: 0;
+            cursor: pointer;
         }
+    }
 
-        th, td {
-            padding: 0 4px;
+    .fixture-card__flag-note {
+        color: $accent;
+        font-weight: 500;
+    }
+
+    .possible-changes {
+        margin-top: 8px;
+    }
+
+    .possible-changes--panel {
+        padding: 0;
+    }
+
+    .possible-changes--message {
+        background: lighten($primary-1, 52%);
+        border-radius: 12px;
+        padding: 8px 12px;
+        text-align: center;
+
+        .possible-changes__text {
+            font-size: 12px;
+            color: rgba($black, 0.7);
         }
+    }
 
-        tbody tr {
-            transition: background-color 0.2s ease-in-out;
-        }
+    .fixture-change-panel {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: stretch;
+        justify-content: center;
+        gap: 12px;
+        background: lighten($primary-1, 48%);
+        border-radius: 16px;
+        padding: 16px;
+        box-shadow: 0 6px 18px rgba($black, 0.08);
+        width: 100%;
+    }
 
-        tbody tr:nth-child(odd) {
-            background-color: lighten($primary-1, 52%);
-        }
+    .fixture-change-panel__team {
+        flex: 0 0 auto;
+        min-width: 120px;
+        text-align: center;
+        border-radius: 12px;
+        padding: 12px 16px;
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+        box-shadow: 0 4px 12px rgba($black, 0.06);
+    }
 
-        tbody tr:nth-child(even) {
-            background-color: $white;
-        }
+    .fixture-change-panel__team--home {
+        background: lighten($primary-1, 36%);
+    }
 
-        tbody tr:hover {
-            background-color: lighten($primary-1, 40%);
-        }
+    .fixture-change-panel__team--away {
+        background: lighten($primary-1, 42%);
+    }
 
-        tbody.fixture tr:first-child td {
-            padding-top: 10px;
-            border-top: 2px solid lighten($primary-1, 35%);
-        }
+    .fixture-change-panel__label {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: rgba($black, 0.54);
+    }
 
-        tbody.fixture tr:last-child td {
-            border-bottom: 2px solid lighten($primary-1, 35%);
-        }
-
-        th {
-            @extend .secondaryText;
-        }
-
-        input[type=number] {
-            width: 3em;
-        }
-
-        td.outcome {
-            min-width: 220px;
-
-
-            @include smallscreen {
-                min-width: 0;
-            }
-
-            select {
-                width: 100%;
-                min-height: 64px;
-                padding: 12px 16px;
-                box-sizing: border-box;
-            }
-        }
+    .fixture-change-panel__value {
+        font-size: 22px;
+        font-weight: 500;
+        color: rgba($black, 0.87);
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the fixtures table markup with a card-based structure that keeps existing Knockout bindings and separates details, selectors, outcomes, and flags
- add modern flexbox styling for the new fixture cards, including responsive layouts and refreshed flag controls
- adapt the possible changes panel and ranking message to live within the updated card containers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d2437afe3c8328866a80f69778d519