### PR TITLE
Adjust segmented control element selectors

### DIFF
--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -344,11 +344,11 @@ body {
         }
     }
 
-    label&__segment {
+    label#{&}__segment {
         min-width: 0;
     }
 
-    button&__segment {
+    button#{&}__segment {
         appearance: none;
         background-color: transparent;
     }


### PR DESCRIPTION
## Summary
- rewrite the segmented control label and button element selectors to start with the parent reference using interpolation so the Sass nesting is consistent

## Testing
- bundle exec jekyll build *(fails: bundler cannot install dependencies because rubygems.org returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68d253d23718832883ef91e99c35474b