### PR TITLE
Refine fixture card layout and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,25 +96,33 @@
                     <!-- ko foreach: fixtures -->
                     <div class="fixture-card">
                         <!-- ko if: $data.venueNameAndCountry || $data.kickoff || $data.liveScoreMode || $data.eventPhase -->
-                        <div class="fixture-card__meta">
-                            <div class="fixture-card__meta-item fixture-card__meta-item--kickoff" data-bind="text: kickoff" title="Kickoff in your browser time"></div>
-                            <div class="fixture-card__meta-item fixture-card__meta-item--phase" data-bind="text: ($data.eventPhase && $data.liveScoreMode) ? ($data.eventPhase + ' (' + $data.liveScoreMode + ')') : ($data.eventPhase || $data.liveScoreMode)"></div>
-                            <div class="fixture-card__meta-item fixture-card__meta-item--venue" data-bind="text: venueNameAndCountry, attr: { title: venueCity }"></div>
+                        <div class="fixture-card__hero">
+                            <div class="fixture-card__hero-meta">
+                                <div class="fixture-card__hero-item fixture-card__hero-item--kickoff" data-bind="text: kickoff" title="Kickoff in your browser time"></div>
+                                <div class="fixture-card__hero-item fixture-card__hero-item--phase" data-bind="text: ($data.eventPhase && $data.liveScoreMode) ? ($data.eventPhase + ' (' + $data.liveScoreMode + ')') : ($data.eventPhase || $data.liveScoreMode)"></div>
+                                <div class="fixture-card__hero-item fixture-card__hero-item--venue" data-bind="text: venueNameAndCountry, attr: { title: venueCity }"></div>
+                            </div>
                         </div>
                         <!-- /ko -->
                         <div class="fixture-card__content">
-                            <div class="fixture-card__section fixture-card__section--teams">
-                                <div class="fixture-card__team fixture-card__team--home">
-                                    <span class="fixture-card__label">Home team</span>
-                                    <select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: homeId, optionsCaption: homeCaption, disabled: !$data.canEditTeams() || $data.alreadyInRankings"></select>
+                            <div class="fixture-card__decision-board">
+                                <div class="fixture-card__decision-column fixture-card__decision-column--left">
+                                    <div class="fixture-card__team fixture-card__team--home">
+                                        <span class="fixture-card__label">Home team</span>
+                                        <select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: homeId, optionsCaption: homeCaption, disabled: !$data.canEditTeams() || $data.alreadyInRankings"></select>
+                                        <span class="fixture-card__rating-badge" data-bind="text: $data.homeRankingBefore() ? $data.homeRankingBefore().toFixed(2) + ' pts' : '—'"></span>
+                                    </div>
+                                    <div class="fixture-card__outcome">
+                                        <span class="fixture-card__label">Outcome</span>
+                                        <select data-bind="options: outcomeOptions, optionsText: 'label', optionsValue: 'value', optionsCaption: outcomeCaption, value: result, valueAllowUnset: true, disabled: alreadyInRankings"></select>
+                                    </div>
                                 </div>
-                                <div class="fixture-card__outcome">
-                                    <span class="fixture-card__label">Outcome</span>
-                                    <select data-bind="options: outcomeOptions, optionsText: 'label', optionsValue: 'value', optionsCaption: outcomeCaption, value: result, valueAllowUnset: true, disabled: alreadyInRankings"></select>
-                                </div>
-                                <div class="fixture-card__team fixture-card__team--away">
-                                    <span class="fixture-card__label">Away team</span>
-                                    <select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: awayId, optionsCaption: awayCaption, disabled: !$data.canEditTeams() || $data.alreadyInRankings"></select>
+                                <div class="fixture-card__decision-column fixture-card__decision-column--right">
+                                    <div class="fixture-card__team fixture-card__team--away">
+                                        <span class="fixture-card__label">Away team</span>
+                                        <select data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: awayId, optionsCaption: awayCaption, disabled: !$data.canEditTeams() || $data.alreadyInRankings"></select>
+                                        <span class="fixture-card__rating-badge" data-bind="text: $data.awayRankingBefore() ? $data.awayRankingBefore().toFixed(2) + ' pts' : '—'"></span>
+                                    </div>
                                 </div>
                             </div>
                             <div class="fixture-card__section fixture-card__section--flags">

--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -469,40 +469,68 @@ body {
         flex-direction: column;
         gap: 16px;
         background: $white;
-        border-radius: 16px;
-        border: 1px solid lighten($primary-1, 35%);
-        box-shadow: 0 10px 24px rgba($black, 0.08);
-        padding: 16px;
+        border-radius: 20px;
+        border: 1px solid lighten($primary-1, 32%);
+        box-shadow: 0 16px 32px rgba($black, 0.08);
+        padding: 20px;
     }
 
-    .fixture-card__meta {
+    .fixture-card__hero {
+        background: linear-gradient(135deg, lighten($primary-1, 20%), lighten($primary-1, 36%));
+        border-radius: 16px;
+        padding: 16px 20px;
+        color: rgba($white, 0.92);
+        box-shadow: inset 0 1px 0 rgba($white, 0.24);
+    }
+
+    .fixture-card__hero-meta {
         display: flex;
         flex-wrap: wrap;
-        gap: 8px 16px;
-        font-size: 11px;
-        color: rgba($black, 0.54);
+        align-items: center;
+        gap: 12px 24px;
+        font-size: 12px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+    }
 
-        .fixture-card__meta-item {
-            flex: 1 1 160px;
+    .fixture-card__hero-item {
+        display: inline-flex;
+        align-items: center;
+        gap: 10px;
+        position: relative;
+
+        &::before {
+            content: '';
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 28px;
+            height: 28px;
+            border-radius: 999px;
+            background: rgba($white, 0.18);
+            box-shadow: inset 0 0 0 1px rgba($white, 0.18);
+            color: $white;
+            font-size: 14px;
         }
     }
 
-    .fixture-card__meta-item--kickoff {
-        text-align: left;
+    .fixture-card__hero-item--kickoff::before {
+        content: '⏰';
     }
 
-    .fixture-card__meta-item--phase {
-        text-align: center;
+    .fixture-card__hero-item--phase::before {
+        content: '🏁';
     }
 
-    .fixture-card__meta-item--venue {
-        text-align: right;
+    .fixture-card__hero-item--venue::before {
+        content: '🏟';
     }
 
     @include smallscreen {
-        .fixture-card__meta-item--phase,
-        .fixture-card__meta-item--venue {
-            text-align: left;
+        .fixture-card__hero-meta {
+            flex-direction: column;
+            align-items: flex-start;
+            gap: 10px;
         }
     }
 
@@ -518,34 +546,76 @@ body {
         gap: 8px;
     }
 
-    .fixture-card__section--teams {
-        gap: 12px;
+    .fixture-card__decision-board {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 24px;
+        background: lighten($primary-1, 54%);
+        border-radius: 18px;
+        padding: 20px;
+        border: 1px solid lighten($primary-1, 34%);
+        box-shadow: inset 0 0 0 1px rgba($white, 0.4);
+    }
 
-        @include largescreen {
-            flex-direction: row;
-            align-items: flex-end;
+    .fixture-card__decision-column {
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+    }
+
+    .fixture-card__team,
+    .fixture-card__outcome {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .fixture-card__outcome {
+        margin-top: auto;
+    }
+
+    .fixture-card__team select,
+    .fixture-card__outcome select {
+        width: 100%;
+        min-height: 56px;
+        padding: 12px 16px;
+        border-radius: 14px;
+        border: 1px solid lighten($primary-1, 28%);
+        background: $white;
+        box-shadow: 0 4px 10px rgba($black, 0.05);
+        box-sizing: border-box;
+    }
+
+    .fixture-card__rating-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        align-self: flex-start;
+        padding: 6px 14px;
+        border-radius: 999px;
+        background: rgba($accent, 0.12);
+        color: darken($accent, 6%);
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        box-shadow: inset 0 0 0 1px rgba($accent, 0.18);
+    }
+
+    .fixture-card__rating-badge::before {
+        content: '★';
+        font-size: 12px;
+    }
+
+    @include smallscreen {
+        .fixture-card__decision-board {
+            grid-template-columns: 1fr;
+            padding: 16px;
+            gap: 16px;
         }
 
-        .fixture-card__team,
         .fixture-card__outcome {
-            display: flex;
-            flex-direction: column;
-            gap: 6px;
-            flex: 1 1 0;
-        }
-
-        .fixture-card__outcome {
-            flex: 1.2 1 0;
-        }
-
-        select {
-            width: 100%;
-            min-height: 56px;
-            padding: 12px 16px;
-            border-radius: 12px;
-            border: 1px solid lighten($primary-1, 30%);
-            background: lighten($primary-1, 55%);
-            box-sizing: border-box;
+            margin-top: 0;
         }
     }
 


### PR DESCRIPTION
## Summary
- wrap fixture metadata in a hero header and split the team/outcome selectors into a two-column decision board
- surface pre-match rating badges alongside the selectors using existing Knockout data
- refresh fixture card visuals for the hero banner and decision board with responsive fallbacks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d266dd65b883288560dea59a9c3902