### PR TITLE
Move fixture flags to header buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,15 +95,36 @@
                 <div class="fixtures-list">
                     <!-- ko foreach: fixtures -->
                     <div class="fixture-card">
-                        <!-- ko if: $data.venueNameAndCountry || $data.kickoff || $data.liveScoreMode || $data.eventPhase -->
                         <div class="fixture-card__hero">
+                            <!-- ko if: $data.venueNameAndCountry || $data.kickoff || $data.liveScoreMode || $data.eventPhase -->
                             <div class="fixture-card__hero-meta">
                                 <div class="fixture-card__hero-item fixture-card__hero-item--kickoff" data-bind="text: kickoff" title="Kickoff in your browser time"></div>
                                 <div class="fixture-card__hero-item fixture-card__hero-item--phase" data-bind="text: ($data.eventPhase && $data.liveScoreMode) ? ($data.eventPhase + ' (' + $data.liveScoreMode + ')') : ($data.eventPhase || $data.liveScoreMode)"></div>
                                 <div class="fixture-card__hero-item fixture-card__hero-item--venue" data-bind="text: venueNameAndCountry, attr: { title: venueCity }"></div>
                             </div>
+                            <!-- /ko -->
+                            <div class="fixture-card__flags" role="group" aria-label="Fixture flags">
+                                <button type="button"
+                                        class="fixture-card__flag"
+                                        title="No Home Advantage"
+                                        data-bind="css: { 'fixture-card__flag--active': noHome, 'fixture-card__flag--disabled': alreadyInRankings },
+                                                   attr: { 'aria-pressed': noHome, 'aria-disabled': alreadyInRankings ? 'true' : null },
+                                                   enable: !$data.alreadyInRankings,
+                                                   click: function () { if (!$data.alreadyInRankings) { noHome(!noHome()); } }">
+                                    <span class="fixture-card__flag-text">NHA</span>
+                                    <span class="fixture-card__flag-note" data-bind="if: switched" title="Home team is nominally Away">*</span>
+                                </button>
+                                <button type="button"
+                                        class="fixture-card__flag"
+                                        title="Is Rugby World Cup match"
+                                        data-bind="css: { 'fixture-card__flag--active': isRwc, 'fixture-card__flag--disabled': alreadyInRankings },
+                                                   attr: { 'aria-pressed': isRwc, 'aria-disabled': alreadyInRankings ? 'true' : null },
+                                                   enable: !$data.alreadyInRankings,
+                                                   click: function () { if (!$data.alreadyInRankings) { isRwc(!isRwc()); } }">
+                                    <span class="fixture-card__flag-text">RWC</span>
+                                </button>
+                            </div>
                         </div>
-                        <!-- /ko -->
                         <div class="fixture-card__content">
                             <div class="fixture-card__decision-board">
                                 <div class="fixture-card__decision-column fixture-card__decision-column--left">
@@ -133,20 +154,6 @@
                                         <select class="plain-text-select" data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: awayId, optionsCaption: awayCaption, disabled: !$data.canEditTeams() || $data.alreadyInRankings"></select>
                                         <span class="fixture-card__rating-badge" data-bind="text: $data.awayRankingBefore() ? $data.awayRankingBefore().toFixed(2) + ' pts' : '—'"></span>
                                     </div>
-                                </div>
-                            </div>
-                            <div class="fixture-card__section fixture-card__section--flags">
-                                <span class="fixture-card__label">Flags</span>
-                                <div class="fixture-card__flags">
-                                    <label class="fixture-card__flag" title="No Home Advantage">
-                                        <input type="checkbox" data-bind="checked: noHome, click: preventCheckboxToggle, event: { keydown: preventCheckboxToggle }" />
-                                        <span class="fixture-card__flag-text">NHA</span>
-                                        <span class="fixture-card__flag-note" data-bind="if: switched" title="Home team is nominally Away">*</span>
-                                    </label>
-                                    <label class="fixture-card__flag" title="Is Rugby World Cup match">
-                                        <input type="checkbox" data-bind="checked: isRwc, click: preventCheckboxToggle, event: { keydown: preventCheckboxToggle }" />
-                                        <span class="fixture-card__flag-text">RWC</span>
-                                    </label>
                                 </div>
                             </div>
                         </div>

--- a/scripts/models/FixtureViewModel.js
+++ b/scripts/models/FixtureViewModel.js
@@ -96,18 +96,5 @@ var FixtureViewModel = function (parent) {
         return result;
     }, this);
 
-    this.preventCheckboxToggle = function (_, event) {
-        if (event) {
-            if (typeof event.preventDefault === 'function') {
-                event.preventDefault();
-            }
-            if (typeof event.stopPropagation === 'function') {
-                event.stopPropagation();
-            }
-        }
-
-        return false;
-    };
-
     return this;
 };

--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -482,6 +482,11 @@ body {
         padding: 16px 20px;
         color: rgba($black, 0.88);
         box-shadow: inset 0 1px 0 rgba($white, 0.24);
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px 16px;
     }
 
     .fixture-card__hero-meta {
@@ -492,6 +497,8 @@ body {
         font-size: 12px;
         letter-spacing: 0.08em;
         text-transform: uppercase;
+        flex: 1 1 auto;
+        min-width: 200px;
     }
 
     .fixture-card__hero-item {
@@ -528,6 +535,11 @@ body {
     }
 
     @include smallscreen {
+        .fixture-card__hero {
+            flex-direction: column;
+            align-items: stretch;
+        }
+
         .fixture-card__hero-meta {
             flex-direction: column;
             align-items: flex-start;
@@ -671,34 +683,63 @@ body {
         color: rgba($black, 0.54);
     }
 
-    .fixture-card__section--flags {
-        .fixture-card__label {
-            margin-bottom: 4px;
-        }
-    }
-
     .fixture-card__flags {
-        display: flex;
+        display: inline-flex;
         flex-wrap: wrap;
-        gap: 12px;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 8px;
+        margin-left: auto;
     }
 
     .fixture-card__flag {
         display: inline-flex;
         align-items: center;
-        gap: 6px;
-        padding: 8px 12px;
+        gap: 4px;
+        padding: 6px 12px;
         border-radius: 999px;
-        background: lighten($primary-1, 48%);
-        box-shadow: inset 0 0 0 1px lighten($primary-1, 35%);
-        font-size: 12px;
-        color: rgba($black, 0.7);
+        background: lighten($primary-1, 46%);
+        box-shadow: inset 0 0 0 1px lighten($primary-1, 28%);
+        font-size: 11px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        font-weight: 500;
+        color: rgba($black, 0.66);
         cursor: pointer;
+        border: 0;
+        background-clip: padding-box;
+        transition: background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
 
-        input {
-            margin: 0;
-            cursor: pointer;
+        &:focus {
+            outline: none;
         }
+
+        &:focus-visible {
+            outline: 2px solid rgba($accent, 0.6);
+            outline-offset: 2px;
+        }
+
+        &:hover:not(:disabled) {
+            background: lighten($primary-1, 40%);
+            box-shadow: inset 0 0 0 1px lighten($primary-1, 20%);
+        }
+
+        &:disabled,
+        &.fixture-card__flag--disabled {
+            cursor: default;
+            opacity: 0.5;
+        }
+
+        &.fixture-card__flag--active {
+            background: $accent;
+            box-shadow: inset 0 0 0 1px darken($accent, 6%);
+            color: rgba($white, 0.92);
+        }
+    }
+
+    .fixture-card__flag-text {
+        display: inline-block;
+        line-height: 1;
     }
 
     .fixture-card__flag-note {


### PR DESCRIPTION
## Summary
- relocate fixture flag controls into the fixture card header so they sit alongside the match metadata
- replace checkbox inputs with button toggles while keeping the underlying ranking logic unchanged
- update styling to remove the checkbox appearance and drop the no-longer-needed checkbox helper

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_b_68d5329180c88328ac1278b88e4a12a6