### PR TITLE
Allow hero venue text to wrap

### DIFF
--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -534,6 +534,13 @@ body {
         content: '🏟';
     }
 
+    .fixture-card__hero-item--venue {
+        flex: 1 1 100%;
+        align-items: flex-start;
+        white-space: normal;
+        overflow-wrap: anywhere;
+    }
+
     @include smallscreen {
         .fixture-card__hero {
             flex-direction: column;


### PR DESCRIPTION
## Summary
- allow the hero card venue item to take the full row and wrap onto multiple lines

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d539d727948328be996d9400e97d6e