### PR TITLE
Remove Upcoming label from fixture hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,9 @@
                             <!-- ko if: $data.venueNameAndCountry || $data.kickoff || $data.liveScoreMode || $data.eventPhase -->
                             <div class="fixture-card__hero-meta">
                                 <div class="fixture-card__hero-item fixture-card__hero-item--kickoff" data-bind="text: kickoff" title="Kickoff in your browser time"></div>
-                                <div class="fixture-card__hero-item fixture-card__hero-item--phase" data-bind="text: ($data.eventPhase && $data.liveScoreMode) ? ($data.eventPhase + ' (' + $data.liveScoreMode + ')') : ($data.eventPhase || $data.liveScoreMode)"></div>
+                                <!-- ko if: $data.eventPhase || ($data.liveScoreMode && $data.liveScoreMode !== 'Upcoming') -->
+                                <div class="fixture-card__hero-item fixture-card__hero-item--phase" data-bind="text: $data.eventPhase ? ($data.liveScoreMode && $data.liveScoreMode !== 'Upcoming' ? $data.eventPhase + ' (' + $data.liveScoreMode + ')' : $data.eventPhase) : $data.liveScoreMode"></div>
+                                <!-- /ko -->
                                 <div class="fixture-card__hero-item fixture-card__hero-item--venue" data-bind="text: venueNameAndCountry, attr: { title: venueCity }"></div>
                             </div>
                             <!-- /ko -->


### PR DESCRIPTION
## Summary
- hide the fixture hero phase label when the live score mode is only "Upcoming"
- keep showing the event phase and other live score modes as before

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d539fbb0808328ba163bb0459a68c0