### PR TITLE
Nest rating badge within team selection container

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,18 +124,20 @@
                                 <div class="fixture-card__decision-column fixture-card__decision-column--left">
                                     <div class="fixture-card__team fixture-card__team--home">
                                         <span class="fixture-card__label">Home team</span>
-                                        <select 
-                                            class="plain-text-select"   
-                                            data-bind="options: 
-                                            $parent.teams, 
-                                            optionsText: 'displayName', 
-                                            optionsValue: 'id', 
-                                            value: homeId, 
-                                            optionsCaption: homeCaption, 
-                                            disabled: !$data.canEditTeams() || $data.alreadyInRankings">
-                        
-                                            </select>
-                                        <span class="fixture-card__rating-badge" data-bind="text: $data.homeRankingBefore() ? $data.homeRankingBefore().toFixed(2) + ' pts' : '—'"></span>
+                                        <div class="fixture-card__team-selection">
+                                            <select
+                                                class="plain-text-select"
+                                                data-bind="options:
+                                                $parent.teams,
+                                                optionsText: 'displayName',
+                                                optionsValue: 'id',
+                                                value: homeId,
+                                                optionsCaption: homeCaption,
+                                                disabled: !$data.canEditTeams() || $data.alreadyInRankings">
+
+                                                </select>
+                                            <span class="fixture-card__rating-badge" data-bind="text: $data.homeRankingBefore() ? $data.homeRankingBefore().toFixed(2) + ' pts' : '—'"></span>
+                                        </div>
                                     </div>
                                     <div class="fixture-card__outcome">
                                         <span class="fixture-card__label">Outcome</span>
@@ -145,8 +147,10 @@
                                 <div class="fixture-card__decision-column fixture-card__decision-column--right">
                                     <div class="fixture-card__team fixture-card__team--away">
                                         <span class="fixture-card__label">Away team</span>
-                                        <select class="plain-text-select" data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: awayId, optionsCaption: awayCaption, disabled: !$data.canEditTeams() || $data.alreadyInRankings"></select>
-                                        <span class="fixture-card__rating-badge" data-bind="text: $data.awayRankingBefore() ? $data.awayRankingBefore().toFixed(2) + ' pts' : '—'"></span>
+                                        <div class="fixture-card__team-selection">
+                                            <select class="plain-text-select" data-bind="options: $parent.teams, optionsText: 'displayName', optionsValue: 'id', value: awayId, optionsCaption: awayCaption, disabled: !$data.canEditTeams() || $data.alreadyInRankings"></select>
+                                            <span class="fixture-card__rating-badge" data-bind="text: $data.awayRankingBefore() ? $data.awayRankingBefore().toFixed(2) + ' pts' : '—'"></span>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -601,6 +601,20 @@ body {
         gap: 8px;
     }
 
+    .fixture-card__team-selection {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+    }
+
+    .fixture-card__team-selection .plain-text-select {
+        flex: 1;
+    }
+
+    .fixture-card__team-selection .fixture-card__rating-badge {
+        flex-shrink: 0;
+    }
+
     .fixture-card__outcome {
         margin-top: auto;
         position: relative;


### PR DESCRIPTION
## Summary
- wrap each fixture team selector and its ranking badge in a new `.fixture-card__team-selection` container
- keep the existing badge styling while allowing it to sit alongside the team name selection control

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d53a28b4608328b344cd63b7e84a02