### PR TITLE
Center venue text beside fixture icon

### DIFF
--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -536,7 +536,7 @@ body {
 
     .fixture-card__hero-item--venue {
         flex: 1 1 100%;
-        align-items: flex-start;
+        align-items: center;
         white-space: normal;
         overflow-wrap: anywhere;
     }


### PR DESCRIPTION
## Summary
- align the fixture card venue metadata content vertically with its icon

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d544aa47cc8328bdd73acbce064605