### PR TITLE
Align ranking badge with team names

### DIFF
--- a/styles/wr-calc.scss
+++ b/styles/wr-calc.scss
@@ -648,7 +648,7 @@ body {
         display: inline-flex;
         align-items: center;
         gap: 6px;
-        align-self: flex-start;
+        align-self: center;
         padding: 0;
         border-radius: 0;
         background: none;
@@ -658,7 +658,7 @@ body {
         letter-spacing: 0.08em;
         text-transform: uppercase;
         box-shadow: none;
-        margin-top: 8px;
+        margin-top: 0;
     }
     .fixture-card__outcome::after {
   content: "▼"; /* or replace with an SVG background */


### PR DESCRIPTION
## Summary
- center the fixture ranking badge alongside the team selector to vertically align the text with team names

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d544d1283883288e7444bcbb80fc93